### PR TITLE
Changed absolute path to strainline scripts

### DIFF
--- a/src/strainline.sh
+++ b/src/strainline.sh
@@ -315,7 +315,7 @@ if [[ $input_fa == "" ]]; then
   exit 1
 fi
 
-basepath=$(dirname $0)
+basepath="$( cd -- "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 
 ##############################################
 ######## Step1: read error correction ########


### PR DESCRIPTION
Hi, 

I had an issue running Strainline using its relative path (I just saw it was deprecated in the README.md):
```
Strainline/src/strainline.sh -i reads.fasta -o out -p ont -t 15
```
The error message was: 
```
Step1: read error correction. Finished.
python: can't open file '/<abs path to>/out/Strainline/src/reformat_fa.py': [Errno 2] No such file or directory
```

I think it is because the path to Strainline scripts was computed with `basepath=$(dirname $0)`. I changed it to compute the absolute path to Strainline scripts. It worked for me, I hope it can be useful.

Best